### PR TITLE
Inclusión de las rutas de los archivos cpts.php y taxs.php fuera del plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+####Description
+Module that loads the taxonomies, custom post types and acf created in other modules.
+Taxonomies(taxs.php) and custom post types(cpts.php) load them into template directories, styles, and wp-content.
+The acf saves them in json in wp-content / acf-groups.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-####Description
+#### Description
 Module that loads the taxonomies, custom post types and acf created in other modules.
 Taxonomies(taxs.php) and custom post types(cpts.php) load them into template directories, styles, and wp-content.
 The acf saves them in json in wp-content / acf-groups.

--- a/cpt.php
+++ b/cpt.php
@@ -1,9 +1,0 @@
-<?php
-
-class Cpts {
-
-    public function __construct() {
-        
-    }
-
-}

--- a/data-model.php
+++ b/data-model.php
@@ -3,13 +3,8 @@
 /*
   Plugin Name: Modelo de datos
   Description: Modelo de datos con los CPT, Taxonomías y ACF
-  Version: 1.1
+  Version: 1.2
  */
-
-/** Custom post types * */
-require_once( plugin_dir_path(__FILE__) . 'cpt.php' );
-/** Taxonomies * */
-require_once( plugin_dir_path(__FILE__) . 'tax.php' );
 
 class DataModel {
 
@@ -19,23 +14,49 @@ class DataModel {
         add_filter('acf/settings/save_json', array($this, 'acf_json_save_point'));
         add_filter('acf/settings/load_json', array($this, 'acf_json_load_point'));
     }
+    //Load the routes where you are $file and make the includes
+    public function register_rutes($file) {
+        $rutes[] = get_template_directory() . $file;
+        $rutes[] = get_stylesheet_directory() . $file;
+        $rutes[] = "/wp-content/" . $file;
+        $pluginsActives = wp_get_active_and_valid_plugins();
+        $directoryPlugins = array();
+        foreach ($pluginsActives as $value) {
+            $directoryPlugins[] = plugin_dir_path($value) . $file;
+        }
+        $rutes = array_merge($rutes, $directoryPlugins);
+        $rutes = array_unique($rutes);
+        foreach ($rutes as $rute) {
+            if (file_exists($rute)) {
+                include $rute;
+            }
+        }
+    }
 
     public function register_cpts() {
-        new Cpts();
+        $this->register_rutes("cpts.php");
     }
 
     public function register_taxs() {
-        new Taxs();
+        $this->register_rutes("taxs.php");
+    }
+    //Verify that the route exists, otherwise he believes create
+    public function check_route($route) {
+        if (!file_exists($route)) {
+            mkdir($route, 0777, true);
+            chown($route, 'root');
+        }
     }
 
     public function acf_json_save_point($path) {
-        $path = plugin_dir_path(__FILE__) . 'acf-groups/';
+        $path = dirname(__FILE__, 3) . '/acf-groups/';
+        $this->check_route($path);
         return $path;
     }
 
     public function acf_json_load_point($paths) {
         unset($paths[0]);
-        $paths[] = plugin_dir_path(__FILE__) . 'acf-groups/';
+        $paths[] = dirname(__FILE__, 3) . '/acf-groups/';
         return $paths;
     }
 

--- a/tax.php
+++ b/tax.php
@@ -1,9 +1,0 @@
-<?php
-
-class Taxs {
-
-    public function __construct() {
-        
-    }
-
-}


### PR DESCRIPTION
Realizadas las modificaciones para incluir las rutas de los archivos cpts.php y taxs.php existentes fuera del plugin y guardar y cargar los acf fuera del plugin